### PR TITLE
added equatesTo method

### DIFF
--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -303,7 +303,7 @@ class Isbn
     }
 
     /**
-     * Check if $this is euqal to another ISBN. As both ISBN are converted to ISBN-13,
+     * Check if $this is equal to another ISBN. As both ISBN are converted to ISBN-13,
      * an ISBN-10 is considered equal to its corresponsing ISBN-13. In conclusion,
      * Isbn::of('978-0-399-16534-4')->isEqualTo("0-399-16534-7") returns true.
      * 

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -303,6 +303,21 @@ class Isbn
     }
 
     /**
+     * Check if $this equates to another ISBN. As both ISBN are converted to ISBN-13,
+     * an ISBN-10 is considered equal to its corresponsing ISBN-13. In conclusion,
+     * Isbn::of('978-0-399-16534-4')->equates("0-399-16534-7") results in true.
+     * 
+     */
+    public function equatesTo($otherIsbn) : bool
+    {
+        if (!$otherIsbn instanceof Isbn) {
+            $otherIsbn = Isbn::of($otherIsbn);
+        }
+
+        return $this->to13() == $otherIsbn->to13();
+    }
+
+    /**
      * Returns the unformatted ISBN number.
      *
      * @return string

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -303,18 +303,18 @@ class Isbn
     }
 
     /**
-     * Check if $this equates to another ISBN. As both ISBN are converted to ISBN-13,
+     * Check if $this is euqal to another ISBN. As both ISBN are converted to ISBN-13,
      * an ISBN-10 is considered equal to its corresponsing ISBN-13. In conclusion,
-     * Isbn::of('978-0-399-16534-4')->equates("0-399-16534-7") results in true.
+     * Isbn::of('978-0-399-16534-4')->isEqualTo("0-399-16534-7") returns true.
      * 
      */
-    public function equatesTo($otherIsbn) : bool
+    public function isEqualTo($otherIsbn) : bool
     {
         if (!$otherIsbn instanceof self) {
             $otherIsbn = self::of($otherIsbn);
         }
 
-        return $this->to13() == $otherIsbn->to13();
+        return $this->to13()->isbn === $otherIsbn->to13()->isbn;
     }
 
     /**

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -310,8 +310,8 @@ class Isbn
      */
     public function equatesTo($otherIsbn) : bool
     {
-        if (!$otherIsbn instanceof Isbn) {
-            $otherIsbn = Isbn::of($otherIsbn);
+        if (!$otherIsbn instanceof self) {
+            $otherIsbn = self::of($otherIsbn);
         }
 
         return $this->to13() == $otherIsbn->to13();

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -308,12 +308,8 @@ class Isbn
      * Isbn::of('978-0-399-16534-4')->isEqualTo("0-399-16534-7") returns true.
      * 
      */
-    public function isEqualTo($otherIsbn) : bool
+    public function isEqualTo(self $otherIsbn) : bool
     {
-        if (!$otherIsbn instanceof self) {
-            $otherIsbn = self::of($otherIsbn);
-        }
-
         return $this->to13()->isbn === $otherIsbn->to13()->isbn;
     }
 

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -355,32 +355,30 @@ class IsbnTest extends TestCase
     }
 
     /**
-     * @dataProvider providerEquations
+     * @dataProvider providerIsEqualTo
      *
      * @param string $isbn Any ISBN.
-     * @param string $anotherIsbn The ISBN-10 that is expected to equate $isbn.
+     * @param string $anotherIsbn The ISBN-10 that is expected to be equal to $isbn.
      */
-    public function testIsbnEquations(string $isbn, string $anotherIsbn) : void
+    public function testIsbnIsEqualTo(string $isbn, string $anotherIsbn, bool $isEqual) : void
     {
-        $this->assertTrue(Isbn::of($isbn)->equatesTo($anotherIsbn));
+        $this->assertTrue(Isbn::of($isbn)->isEqualTo($anotherIsbn) === $isEqual);
     }
+
     /**
      * @return array
      */
-
-    public function providerEquations() : array
+    public function providerIsEqualTo() : array
     {
         return [
-            ['9780123456786', '0123456789'],
-            ['9781234567897', '123456789X'],
-            ['9782345678908', '2345678909'],
-            ['9783456789019', '3456789017'],
-            ['9784567890120', '4567890124'],
-            ['5678901230', '9785678901231'],
-            ['6789012346', '9786789012342'],
-            ['7890123450', '9787890123453'],
-            ['8901234564', '9788901234564'],
-            ['9012345677', '9789012345675'],
+            ['9780123456786', '0123456789', true],
+            ['9781234567897', '123456789X', true],
+            ['5678901230', '9785678901231', true],
+            ['6789012346', '9786789012342', true],
+            ['9783456789019', '123456789X', false],
+            ['9784567890120', '123456789X', false],
+            ['8901234564', '9786789012342', false],
+            ['9012345677', '9786789012342', false],
         ];
     }
 }

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -353,4 +353,34 @@ class IsbnTest extends TestCase
 
         $this->fail('Failed asserting that exception of type ' . $expectedException . ' is thrown.');
     }
+
+    /**
+     * @dataProvider providerEquations
+     *
+     * @param string $isbn Any ISBN.
+     * @param string $anotherIsbn The ISBN-10 that is expected to equate $isbn.
+     */
+    public function testIsbnEquations(string $isbn, string $anotherIsbn) : void
+    {
+        $this->assertTrue(Isbn::of($isbn)->equatesTo($anotherIsbn));
+    }
+    /**
+     * @return array
+     */
+
+    public function providerEquations() : array
+    {
+        return [
+            ['9780123456786', '0123456789'],
+            ['9781234567897', '123456789X'],
+            ['9782345678908', '2345678909'],
+            ['9783456789019', '3456789017'],
+            ['9784567890120', '4567890124'],
+            ['5678901230', '9785678901231'],
+            ['6789012346', '9786789012342'],
+            ['7890123450', '9787890123453'],
+            ['8901234564', '9788901234564'],
+            ['9012345677', '9789012345675'],
+        ];
+    }
 }

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -362,7 +362,7 @@ class IsbnTest extends TestCase
      */
     public function testIsbnIsEqualTo(string $isbn, string $anotherIsbn, bool $isEqual) : void
     {
-        $this->assertTrue(Isbn::of($isbn)->isEqualTo($anotherIsbn) === $isEqual);
+        $this->assertTrue(Isbn::of($isbn)->isEqualTo(Isbn::of($anotherIsbn)) === $isEqual);
     }
 
     /**


### PR DESCRIPTION
The equatesTo() method compares any other Isbn to the instance. It returns true if both ISBN are the same, obviously, but also when one is ISBN-10 and the other the corresponding ISBN-13.