### PR TITLE
Add Detect tag without new commit workflow

### DIFF
--- a/.github/workflows/duplicate-tags.yml
+++ b/.github/workflows/duplicate-tags.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow
+
+name: "Tags"
+
+on:
+  push:
+    tags:
+      - "**"
+
+permissions:
+  contents: "read"
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  double_tag:
+    name: "Detect tag without new commit"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 1
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@v3"
+      - name: "List commits with multiple tags"
+        run: |
+          ! git show-ref --tags | cut -d ' ' -f 1 | sort | uniq -d

--- a/.github/workflows/duplicate-tags.yml
+++ b/.github/workflows/duplicate-tags.yml
@@ -24,4 +24,9 @@ jobs:
         uses: "actions/checkout@v3"
       - name: "List commits with multiple tags"
         run: |
-          ! git show-ref --tags | cut -d ' ' -f 1 | sort | uniq -d
+          DUPLICATES="$(git show-ref --tags --hash=7 | sort | uniq --repeated)"
+          if [ -n "${DUPLICATES}" ]; then
+              echo "::error::Commit with multiple tags"
+              echo "${DUPLICATES}"
+              exit 10
+          fi


### PR DESCRIPTION
It should find these.
```
d03c4d7f50770a0f362a695668c57b58a78c63d0 refs/tags/0.2.90
d03c4d7f50770a0f362a695668c57b58a78c63d0 refs/tags/0.2.91

592e64622127c51b7ab0cc3213b85dfcdc8b9b0b refs/tags/0.3.14
592e64622127c51b7ab0cc3213b85dfcdc8b9b0b refs/tags/0.3.15
592e64622127c51b7ab0cc3213b85dfcdc8b9b0b refs/tags/0.3.16

eb43ed0326dc8a2934ed1b8601fc4279d36f7a91 refs/tags/0.3.25
eb43ed0326dc8a2934ed1b8601fc4279d36f7a91 refs/tags/0.3.26

54fc98543a6d304e28fd903f347a63384c5b4f93 refs/tags/0.3.27
54fc98543a6d304e28fd903f347a63384c5b4f93 refs/tags/0.3.28

8e7230b36dd568095d964dc0bd64e84e68cc5dcb refs/tags/0.3.42
8e7230b36dd568095d964dc0bd64e84e68cc5dcb refs/tags/0.3.43
```
Then I should come up with an exclusion list.
